### PR TITLE
Add a security policy for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability in prek-action, [open a private vulnerability report](https://github.com/j178/prek-action/security/advisories/new) and you can create a patch on a private fork or, after reporting the problem, our maintainers will fix it as soon as possible.


### PR DESCRIPTION
Hi! I've found a security vulnerability in the action and I want to send a patch, but that would make the patch public and possible attackers could compromise repositories that are using prek-action.

So to start with the process, I'm opening this to create a *SECURITY.md* document that will enable `Security policy` in the repository `Security` tab.

![image](https://github.com/user-attachments/assets/4d856fe0-fb9b-4250-923e-942304ff0077)

To send the patch in a private fork, that will not be public, I need that someone with write access to the settings enable `Private vulnerability reporting`. The other `Security advisories` can be enabled also without publishing all reports as each report can be marked as public or not later.

See [_Secure coding documentation_](https://docs.github.com/en/code-security). The part that concers to this PR is [_Working with security advisories_](https://docs.github.com/en/code-security/security-advisories), concretely [_Configuring private vulnerability reporting for a repository_](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) and [_Creating a repository security advisory_](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory).