### PR TITLE
Remove GitHub API usage

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -112,7 +112,7 @@ runs:
     if: runner.os == 'Windows'
     shell: pwsh
     run: |
-      $raw = (& prek --version) 2>$null -join ' '
+      $raw = -join (& prek --version 2>$null)
       $m = [regex]::Match($raw, '\d+(\.\d+){1,3}')
       $ver = if ($m.Success) { "v$($m.Value)" } else { 'vunknown' }
       "version=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
Hello there! I noticed that the API was unnecessary so I asked AI to improve this and I edited the results a bit. Additionally, running the tool now no longer uses Python to avoid the overhead (at least on Linux, PowerShell is probably heavier but hooks are less likely to run on Windows and dozens of milliseconds are not much anyway).