### PR TITLE
ci: add zizmor security scanning workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: Run zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Upload SARIF results to GitHub Security tab
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run pre-commit hooks
+        uses: ./
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1


### PR DESCRIPTION
Add workflow for scanning GitHub Actions with zizmor.

- Run prek to execute all pre-commit hooks (dogfooding + builtin hooks like trailing-whitespace, end-of-file-fixer, check-yaml)
- Use zizmor-action for SARIF upload to GitHub Security tab

Supersedes #58.