### PR TITLE
ci: add lint job using prek

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Run prek
+        uses: ./
+
   test:
     strategy:
       matrix:


### PR DESCRIPTION
Run prek to execute pre-commit hooks in CI (dogfooding + builtin hooks like trailing-whitespace, end-of-file-fixer, check-yaml).