### PR TITLE
chore: replace .pre-commit-config.yaml with prek.toml

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,13 +11,8 @@
     'internal'
   ],
   semanticCommits: 'disabled',
-  // pre-commit is currently in beta testing, must opt in
-  'pre-commit': {
-    enabled: true
-  },
   enabledManagers: [
     'github-actions',
-    'pre-commit',
     'cargo',
     'custom.regex',
   ],
@@ -44,11 +39,6 @@
       // Pin GitHub Actions to immutable SHAs
       pinDigests: true
     },
-    {
-      groupName: 'pre-commit',
-      matchManagers: ['pre-commit'],
-      matchPaths: ['.pre-commit-config.yaml']
-    },
     // Annotate GitHub Actions SHAs with a SemVer version.
     {
       extends: [
@@ -58,7 +48,7 @@
       versioning: 'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$'
     },
     {
-      matchManagers: [ 'pre-commit', 'github-actions', 'custom.regex' ],
+      matchManagers: [ 'github-actions', 'custom.regex' ],
       minimumReleaseAge: '14 days'
     }
   ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-default_install_hook_types: [ pre-push ]
-repos:
-  - repo: builtin
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,9 @@
+default_install_hook_types = ["pre-push"]
+
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "trailing-whitespace" },
+  { id = "end-of-file-fixer" },
+  { id = "check-yaml" },
+]


### PR DESCRIPTION
Closes #66

Note, removed pre-commit from Renovate config; see renovatebot/renovate#40967 for tracking prek support
