### PR TITLE
ci(renovate): add npm manager, remove stale cargo manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,8 +17,8 @@
   },
   enabledManagers: [
     'github-actions',
+    'npm',
     'pre-commit',
-    'cargo',
     'custom.regex',
   ],
   customManagers: [
@@ -47,7 +47,6 @@
     {
       groupName: 'pre-commit',
       matchManagers: ['pre-commit'],
-      matchPaths: ['.pre-commit-config.yaml']
     },
     // Annotate GitHub Actions SHAs with a SemVer version.
     {
@@ -58,8 +57,20 @@
       versioning: 'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$'
     },
     {
-      matchManagers: [ 'pre-commit', 'github-actions', 'custom.regex' ],
+      matchManagers: [ 'npm', 'pre-commit', 'github-actions', 'custom.regex' ],
       minimumReleaseAge: '14 days'
-    }
+    },
+    // Group @actions/* toolkit packages together
+    {
+      groupName: 'GitHub Actions toolkit',
+      matchManagers: ['npm'],
+      matchPackageNames: ['@actions/**'],
+    },
+    // Group dev dependencies together
+    {
+      groupName: 'npm dev dependencies',
+      matchManagers: ['npm'],
+      matchDepTypes: ['devDependencies'],
+    },
   ]
 }


### PR DESCRIPTION
Also removes `matchPaths` from the `pre-commit` manager. This is a deprecated field, and also unnecessary (the `pre-commit` manager only applies to the `.pre-commit-config.yaml` file in the first place).