### PR TITLE
Fix cache key hashing

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -65129,8 +65129,9 @@ async function hashConfigFiles(workingDirectory) {
   for (const file of files.sort()) {
     digest.update(path18.relative(workingDirectory, file));
     digest.update("\0");
-    digest.update(await fs10.readFile(file));
-    digest.update("\0");
+    digest.update(
+      crypto4.createHash("sha256").update(await fs10.readFile(file)).digest()
+    );
   }
   return digest.digest("hex");
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -103,8 +103,12 @@ async function hashConfigFiles(workingDirectory: string): Promise<string> {
   for (const file of files.sort()) {
     digest.update(path.relative(workingDirectory, file))
     digest.update('\0')
-    digest.update(await fs.readFile(file))
-    digest.update('\0')
+    digest.update(
+      crypto
+        .createHash('sha256')
+        .update(await fs.readFile(file))
+        .digest(),
+    )
   }
   return digest.digest('hex')
 }


### PR DESCRIPTION
This fixes cache key computation to be similar to [what GHA's actions toolkit](https://github.com/actions/toolkit/blob/0786132e6a1a4451c2d392bbbf481c2b172d4312/packages/glob/src/internal-hash-files.ts#L31-L34) does, to avoid a certain class of (unlikely but possible) cache key collision and cache poisoning.