### PR TITLE
Add frozen rev enforcement input

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
 `prek` is always invoked as:
 
 ```text
-prek run --show-diff-on-failure --color=always <extra-args>
+prek run --show-diff-on-failure --color=always [--require-frozen-revs] <extra-args>
 ```
 
 ## Version Tags
@@ -39,6 +39,7 @@ For a stable reference, pin to a specific release tag such as `v2.0.0`, or pin t
 | `extra_args` | Deprecated alias for `extra-args` | No | |
 | `prek-version` | Version or semver range to install, for example `0.2.30`, `0.3.x`, `<=1.0.0`, or `latest` | No | `latest` |
 | `install-only` | Install `prek` but skip `prek run` | No | `false` |
+| `require-frozen-revs` | Pass `--require-frozen-revs` to `prek run` | No | `false` |
 | `working-directory` | Directory where `prek run` is executed | No | `.` |
 | `show-verbose-logs` | Print the `prek` verbose log after `prek run` completes | No | `true` |
 | `cache` | Cache the prek environment between workflow runs | No | `true` |
@@ -110,6 +111,16 @@ steps:
   - uses: j178/prek-action@v2
     with:
       show-verbose-logs: false
+```
+
+Require remote hook repositories to be pinned to commit SHAs:
+
+```yaml
+steps:
+  - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+  - uses: j178/prek-action@0123456789abcdef0123456789abcdef01234567
+    with:
+      require-frozen-revs: true
 ```
 ## Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Only install prek, do not run it
     required: false
     default: "false"
+  require-frozen-revs:
+    description: Pass --require-frozen-revs to `prek run`
+    required: false
+    default: "false"
   prek-version:
     description: Version or semver range of prek to install (for example `0.2.1`, `0.3.x`, `<=1.0.0`, or `latest`)
     required: false

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -64956,11 +64956,12 @@ function firstString() {
 function formatError(error2) {
   return error2 instanceof Error ? error2.message : String(error2);
 }
-async function runPrek(workingDirectory, extraArgs) {
+async function runPrek(workingDirectory, extraArgs, requireFrozenRevs) {
   const args = [
     "run",
     "--show-diff-on-failure",
     "--color=always",
+    ...requireFrozenRevs ? ["--require-frozen-revs"] : [],
     ...parseArgsStringToArgv(extraArgs)
   ];
   return exec("prek", args, {
@@ -65151,6 +65152,7 @@ function getInputs() {
     extraArgs: legacyExtraArgs || modernExtraArgs,
     installOnly: getBooleanInput("install-only"),
     prekVersion: getInput("prek-version") || "latest",
+    requireFrozenRevs: getBooleanInput("require-frozen-revs"),
     showVerboseLogs: getBooleanInput("show-verbose-logs"),
     workingDirectory: getInput("working-directory") || "."
   };
@@ -66932,7 +66934,11 @@ async function run() {
   }
   let exitCode;
   try {
-    exitCode = await runPrek(inputs.workingDirectory, inputs.extraArgs);
+    exitCode = await runPrek(
+      inputs.workingDirectory,
+      inputs.extraArgs,
+      inputs.requireFrozenRevs
+    );
   } finally {
     if (inputs.showVerboseLogs) {
       await showVerboseLogs();

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -10,6 +10,7 @@ export function getInputs(): Inputs {
     extraArgs: legacyExtraArgs || modernExtraArgs,
     installOnly: core.getBooleanInput('install-only'),
     prekVersion: core.getInput('prek-version') || 'latest',
+    requireFrozenRevs: core.getBooleanInput('require-frozen-revs'),
     showVerboseLogs: core.getBooleanInput('show-verbose-logs'),
     workingDirectory: core.getInput('working-directory') || '.',
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,11 @@ export async function run(): Promise<void> {
 
   let exitCode: number | undefined
   try {
-    exitCode = await runPrek(inputs.workingDirectory, inputs.extraArgs)
+    exitCode = await runPrek(
+      inputs.workingDirectory,
+      inputs.extraArgs,
+      inputs.requireFrozenRevs,
+    )
   } finally {
     if (inputs.showVerboseLogs) {
       await showVerboseLogs()

--- a/src/prek.ts
+++ b/src/prek.ts
@@ -9,11 +9,16 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-export async function runPrek(workingDirectory: string, extraArgs: string): Promise<number> {
+export async function runPrek(
+  workingDirectory: string,
+  extraArgs: string,
+  requireFrozenRevs: boolean,
+): Promise<number> {
   const args = [
     'run',
     '--show-diff-on-failure',
     '--color=always',
+    ...(requireFrozenRevs ? ['--require-frozen-revs'] : []),
     ...parseArgsStringToArgv(extraArgs),
   ]
   return exec.exec('prek', args, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type Inputs = {
   extraArgs: string
   installOnly: boolean
   prekVersion: string
+  requireFrozenRevs: boolean
   showVerboseLogs: boolean
   workingDirectory: string
 }

--- a/test/inputs.test.ts
+++ b/test/inputs.test.ts
@@ -92,4 +92,13 @@ describe('getInputs', () => {
     ;({ getInputs } = await importInputsModule())
     expect(getInputs().showVerboseLogs).toBe(false)
   })
+
+  it('disables frozen rev enforcement by default and allows opting in', async () => {
+    let { getInputs } = await importInputsModule()
+    expect(getInputs().requireFrozenRevs).toBe(false)
+
+    mockContext.inputs['require-frozen-revs'] = 'true'
+    ;({ getInputs } = await importInputsModule())
+    expect(getInputs().requireFrozenRevs).toBe(true)
+  })
 })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -6,6 +6,7 @@ const mockContext = vi.hoisted(() => ({
     extraArgs: '--all-files',
     installOnly: false,
     prekVersion: 'latest',
+    requireFrozenRevs: false,
     showVerboseLogs: false,
     workingDirectory: '/tmp/repo',
   },
@@ -76,6 +77,7 @@ function resetMockContext(): void {
     extraArgs: '--all-files',
     installOnly: false,
     prekVersion: 'latest',
+    requireFrozenRevs: false,
     showVerboseLogs: false,
     workingDirectory: '/tmp/repo',
   }
@@ -137,6 +139,16 @@ describe('run', () => {
       ['prek-version', 'v0.3.6'],
       ['cache-hit', 'false'],
     ])
+  })
+
+  it('passes frozen rev enforcement through to prek execution', async () => {
+    mockContext.inputs.requireFrozenRevs = true
+
+    const { run } = await importMainModule()
+
+    await run()
+
+    expect(dependencyMocks.runPrek).toHaveBeenCalledWith('/tmp/repo', '--all-files', true)
   })
 })
 

--- a/test/prek.test.ts
+++ b/test/prek.test.ts
@@ -27,7 +27,37 @@ vi.mock('@actions/exec', () => ({
   exec: toolkitMocks.exec,
 }))
 
-const { getPrekCacheDir } = await import('../src/prek')
+const { getPrekCacheDir, runPrek } = await import('../src/prek')
+
+describe('runPrek', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes require-frozen-revs before extra args when enabled', async () => {
+    toolkitMocks.exec.mockResolvedValue(0)
+
+    await runPrek('/tmp/repo', '--all-files', true)
+
+    expect(toolkitMocks.exec).toHaveBeenCalledWith(
+      'prek',
+      ['run', '--show-diff-on-failure', '--color=always', '--require-frozen-revs', '--all-files'],
+      { cwd: '/tmp/repo', ignoreReturnCode: true },
+    )
+  })
+
+  it('omits require-frozen-revs when disabled', async () => {
+    toolkitMocks.exec.mockResolvedValue(0)
+
+    await runPrek('/tmp/repo', '--all-files', false)
+
+    expect(toolkitMocks.exec).toHaveBeenCalledWith(
+      'prek',
+      ['run', '--show-diff-on-failure', '--color=always', '--all-files'],
+      { cwd: '/tmp/repo', ignoreReturnCode: true },
+    )
+  })
+})
 
 describe('getPrekCacheDir', () => {
   beforeEach(() => {


### PR DESCRIPTION
Draft because version bump of prek that includes https://github.com/j178/prek/pull/2230 is needed so that needs to be merged first.

Add a require-frozen-revs action input that passes --require-frozen-revs to prek run, document the option with pinned action refs, and cover the input and command construction in tests.

After this PR is merged, a follow-up PR to use the new version in `prek` with this new option enabled should be made so `prek` uses this new security measure.