### PR TITLE
Disable color in `prek cache dir` output

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -65318,7 +65318,6 @@ function create2(patterns, options) {
 var fs9 = __toESM(require("node:fs/promises"), 1);
 var os9 = __toESM(require("node:os"), 1);
 var path17 = __toESM(require("node:path"), 1);
-var import_node_util4 = require("node:util");
 
 // node_modules/string-argv/index.js
 function parseArgsStringToArgv(value, env, file) {
@@ -65404,7 +65403,7 @@ async function getPrekCacheDir() {
   let output = "";
   let code;
   try {
-    code = await exec("prek", ["cache", "dir", "--no-log-file"], {
+    code = await exec("prek", ["cache", "dir", "--no-log-file", "--color=never"], {
       ignoreReturnCode: true,
       listeners: {
         stdout: (data) => {
@@ -65418,7 +65417,7 @@ async function getPrekCacheDir() {
     return getDefaultPrekCacheDir();
   }
   if (code === 0) {
-    const trimmed = (0, import_node_util4.stripVTControlCharacters)(output).trim();
+    const trimmed = output.trim();
     if (trimmed) {
       info(`Using prek cache dir ${trimmed}`);
       return trimmed;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -65318,6 +65318,7 @@ function create2(patterns, options) {
 var fs9 = __toESM(require("node:fs/promises"), 1);
 var os9 = __toESM(require("node:os"), 1);
 var path17 = __toESM(require("node:path"), 1);
+var import_node_util4 = require("node:util");
 
 // node_modules/string-argv/index.js
 function parseArgsStringToArgv(value, env, file) {
@@ -65417,7 +65418,7 @@ async function getPrekCacheDir() {
     return getDefaultPrekCacheDir();
   }
   if (code === 0) {
-    const trimmed = output.trim();
+    const trimmed = (0, import_node_util4.stripVTControlCharacters)(output).trim();
     if (trimmed) {
       info(`Using prek cache dir ${trimmed}`);
       return trimmed;

--- a/src/prek.ts
+++ b/src/prek.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import { parseArgsStringToArgv } from 'string-argv'
@@ -74,7 +75,7 @@ export async function getPrekCacheDir(): Promise<string> {
   }
 
   if (code === 0) {
-    const trimmed = output.trim()
+    const trimmed = stripVTControlCharacters(output).trim()
     if (trimmed) {
       core.info(`Using prek cache dir ${trimmed}`)
       return trimmed

--- a/src/prek.ts
+++ b/src/prek.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { stripVTControlCharacters } from 'node:util'
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import { parseArgsStringToArgv } from 'string-argv'
@@ -60,7 +59,7 @@ export async function getPrekCacheDir(): Promise<string> {
   let output = ''
   let code: number
   try {
-    code = await exec.exec('prek', ['cache', 'dir', '--no-log-file'], {
+    code = await exec.exec('prek', ['cache', 'dir', '--no-log-file', '--color=never'], {
       ignoreReturnCode: true,
       listeners: {
         stdout: (data: Buffer) => {
@@ -75,7 +74,7 @@ export async function getPrekCacheDir(): Promise<string> {
   }
 
   if (code === 0) {
-    const trimmed = stripVTControlCharacters(output).trim()
+    const trimmed = output.trim()
     if (trimmed) {
       core.info(`Using prek cache dir ${trimmed}`)
       return trimmed

--- a/test/prek.test.ts
+++ b/test/prek.test.ts
@@ -43,23 +43,11 @@ describe('getPrekCacheDir', () => {
 
   it('prefers the CLI-reported path', async () => {
     await expect(getPrekCacheDir()).resolves.toBe('/tmp/prek-cache')
-    expect(mockContext.infos).toEqual(['Using prek cache dir /tmp/prek-cache'])
-  })
-
-  it('strips ANSI escapes from the colored CLI-reported path', async () => {
-    const originalEnv = { ...process.env }
-    process.env.PREK_COLOR = 'always'
-    toolkitMocks.exec.mockImplementation(async (_commandLine, _args, options) => {
-      options?.listeners?.stdout?.(Buffer.from(`\x1B[36m${mockContext.cacheDir}\x1B[39m\n`))
-      return 0
-    })
-
-    try {
-      await expect(getPrekCacheDir()).resolves.toBe('/tmp/prek-cache')
-    } finally {
-      process.env = originalEnv
-    }
-
+    expect(toolkitMocks.exec).toHaveBeenCalledWith(
+      'prek',
+      ['cache', 'dir', '--no-log-file', '--color=never'],
+      expect.any(Object),
+    )
     expect(mockContext.infos).toEqual(['Using prek cache dir /tmp/prek-cache'])
   })
 

--- a/test/prek.test.ts
+++ b/test/prek.test.ts
@@ -46,6 +46,23 @@ describe('getPrekCacheDir', () => {
     expect(mockContext.infos).toEqual(['Using prek cache dir /tmp/prek-cache'])
   })
 
+  it('strips ANSI escapes from the colored CLI-reported path', async () => {
+    const originalEnv = { ...process.env }
+    process.env.PREK_COLOR = 'always'
+    toolkitMocks.exec.mockImplementation(async (_commandLine, _args, options) => {
+      options?.listeners?.stdout?.(Buffer.from(`\x1B[36m${mockContext.cacheDir}\x1B[39m\n`))
+      return 0
+    })
+
+    try {
+      await expect(getPrekCacheDir()).resolves.toBe('/tmp/prek-cache')
+    } finally {
+      process.env = originalEnv
+    }
+
+    expect(mockContext.infos).toEqual(['Using prek cache dir /tmp/prek-cache'])
+  })
+
   it('falls back to PREK_HOME when the CLI probe fails', async () => {
     const originalEnv = { ...process.env }
     const prekHome = path.join(os.tmpdir(), 'prek-action-prek-home')


### PR DESCRIPTION
## Summary

Pass `--color=never` to `prek cache dir` so its machine-readable output remains a plain path even when `PREK_COLOR=always` is set.

This prevents ANSI escape sequences from reaching `@actions/cache`, where they cause cache path validation to fail.

## Example occurrence

https://github.com/KSmanis/KSmanis/actions/runs/29380410882